### PR TITLE
add multiple jdks to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,9 @@ language: scala
 scala:
   - 2.10.4
 
+jdk:
+  - openjdk7
+  - oraclejdk7
+  - oraclejdk8
+
 sudo: false


### PR DESCRIPTION
Cascade was seeing errors building against JDK 8, so we should also make sure that our other projects compile against JDK 8, too. See https://github.com/paypal/cascade/pull/84