### PR TITLE
add scala 2.11.5 build to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: scala
 
 scala:
   - 2.10.4
+  - 2.11.5
 
 jdk:
   - openjdk7


### PR DESCRIPTION
sbt cross-builds against 2.11, so we may as well, too